### PR TITLE
Use scaleToZoom function.

### DIFF
--- a/zoom_level/zoom_level.py
+++ b/zoom_level/zoom_level.py
@@ -42,8 +42,10 @@ class ZoomLevel:
         """Display the current zoom level in the status bar"""
 
         scale = self.iface.mapCanvas().scale()
-
+        # scale denominator at zoom level 0 of GoogleCRS84Quad
+        s0 = 559082264.0287178
+        scale = self.iface.mapCanvas().scale()
         # Convert the scale to the equivalent zoom level
         # (This is accurate enough for at least 2 decimal places)
-        zoom = 29.1402 - log2(scale)
+        zoom = log2(s0 / scale) / log2(2) - 1
         self.iface.mainWindow().statusBar().showMessage('Zoom Level {:.2f}'.format(zoom))


### PR DESCRIPTION
Hi,

I use your plugin and it's great, however, sometimes I struggle with its inaccuracy when working with vector tile layers.
There have been added two expression variables `@vector_tile_zoom` and `@zoom_level` recently into QGIS. They are based on `scaleToZoom` function https://github.com/qgis/QGIS/blob/master/src/core/vectortile/qgsvectortileutils.cpp#L63

I used the same formula for this plugin. 
Note: I work with vector tiles so I didn't test it for other than Pseudo-Mercator projection.